### PR TITLE
Fix Error handling for "4.1 add" and "4.2 remove".

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ rvm:
   - jruby-19mode
 before_install:
   - git submodule update --init --recursive
+  - gem update bundler

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,6 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in json-patch.gemspec
 gem 'minitest'
 gem 'coveralls', require: false
+gem 'rake', '~> 10.5.0' if RUBY_VERSION < '1.9.3'
+gem 'rake' if RUBY_VERSION >= '1.9.3'
 gemspec

--- a/lib/json/patch.rb
+++ b/lib/json/patch.rb
@@ -97,7 +97,7 @@ module JSON
     end
 
     def add_object(target_doc, target_item, ref_token, value)
-      raise JSON::PatchError if target_item.nil? 
+      raise JSON::PatchError if (target_item.nil? || !(Hash === target_item))
       if ref_token.nil?
         target_doc.replace(value)
       else
@@ -130,8 +130,10 @@ module JSON
 
       if Array === target_item
         target_item.delete_at ref_token.to_i if valid_index?(target_item, ref_token)
-      else
+      elsif Hash === target_item
         target_item.delete ref_token
+      else
+        raise JSON::PatchError
       end
     end
 

--- a/test/ietf_test.rb
+++ b/test/ietf_test.rb
@@ -34,7 +34,7 @@ describe "IETF JSON Patch Test" do
         describe "JSON::Patch.new" do
           it "#{comment || spec['error'] || index}" do
 
-            target_doc     = spec['doc'] if spec['doc']
+            target_doc     = Marshal.load(Marshal.dump(spec['doc'])) if spec['doc']
             operations_doc = spec['patch'] if spec['patch']
             expected_doc   = spec['expected'] if spec['expected']
 

--- a/test/json-patch_test.rb
+++ b/test/json-patch_test.rb
@@ -121,6 +121,17 @@ describe "Section 4.1: The add operation" do
     end
   end
 
+  describe "the target location MUST reference" do
+    let(:target_document) { %q'{"foo":"bar","baz":"wat"}' }
+    let(:operation_document) { %q'[{ "op": "add", "path": "/baz/quux", "value": "qux" }]' }
+
+    it "will raise exception if the target location is string (neither an array nor object)" do
+      assert_raises(JSON::PatchError) do
+        JSON.patch(target_document, operation_document)
+      end
+    end
+  end
+
 =begin
 TODO
 When the operation is applied, the target location MUST reference one of:
@@ -175,6 +186,18 @@ describe "Section 4.2: The remove operation" do
       end
     end
   end
+
+  describe "The target location MUST exist for the operation to be successful." do
+    let(:target_document) { %q'{"foo":"bar","baz":"qux"}' }
+    let(:operation_document) { %q'[{ "op": "remove", "path": "/foo/baz" }]' }
+
+    it "will rails an exception if the member in the path does not exist" do
+      assert_raises(JSON::PatchError) do
+       JSON.patch(target_document, operation_document)
+      end
+    end
+  end
+
 
 end
 


### PR DESCRIPTION
@guillec 

Hi, I'm toshiya. First of all,  thank you for this great gem. I like it.

I've been using this gem for sometime and find that some subtle error handlings does not satisfies the RFC specification. (Probably, you already know it.) 

This PR contains the fix for the following error cases specified in the RFC.

4.1.  add
When the operation is applied, the target location MUST reference
https://tools.ietf.org/html/rfc6902#section-4.1

4.2. remove
The target location MUST exist for the operation to be successful.
https://tools.ietf.org/html/rfc6902#section-4.2
